### PR TITLE
feat(getcap): use local cache to store getcap for a service url

### DIFF
--- a/gpf_isochrone_isodistance_itineraire/gui/dlg_settings.py
+++ b/gpf_isochrone_isodistance_itineraire/gui/dlg_settings.py
@@ -26,6 +26,7 @@ from gpf_isochrone_isodistance_itineraire.__about__ import (
     __version__,
 )
 from gpf_isochrone_isodistance_itineraire.toolbelt import PlgLogger, PlgOptionsManager
+from gpf_isochrone_isodistance_itineraire.toolbelt.cache_manager import CacheManager
 from gpf_isochrone_isodistance_itineraire.toolbelt.preferences import (
     PlgSettingsStructure,
 )
@@ -51,6 +52,7 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         super().__init__(parent)
         self.log = PlgLogger().log
         self.plg_settings = PlgOptionsManager()
+        self.cache_manager = CacheManager()
 
         # load UI and set objectName
         self.setupUi(self)
@@ -87,6 +89,12 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
                 ),
             )
         )
+
+        self.btn_clear_cache.setIcon(
+            # QgsApplication.getThemeIcon("iconClearConsole.svg")
+            QIcon(":images/themes/default/console/iconClearConsole.svg")
+        )
+        self.btn_clear_cache.pressed.connect(partial(self.cache_manager.clear_cache))
 
         self.btn_reset.setIcon(QIcon(QgsApplication.iconPath("mActionUndo.svg")))
         self.btn_reset.pressed.connect(self.reset_settings)

--- a/gpf_isochrone_isodistance_itineraire/gui/dlg_settings.ui
+++ b/gpf_isochrone_isodistance_itineraire/gui/dlg_settings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>854</width>
-    <height>518</height>
+    <width>733</width>
+    <height>491</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -95,8 +95,8 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="1">
-       <widget class="QLabel" name="lbl_version_saved_value">
+      <item row="2" column="0">
+       <widget class="QLabel" name="lbl_version_saved">
         <property name="minimumSize">
          <size>
           <width>0</width>
@@ -113,10 +113,7 @@
          <locale language="English" country="UnitedStates"/>
         </property>
         <property name="text">
-         <string notr="true">X.X.X</string>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::NoTextInteraction</set>
+         <string>Version used to save settings:</string>
         </property>
        </widget>
       </item>
@@ -142,28 +139,6 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="lbl_version_saved">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="locale">
-         <locale language="English" country="UnitedStates"/>
-        </property>
-        <property name="text">
-         <string>Version used to save settings:</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QPushButton" name="btn_help">
         <property name="minimumSize">
@@ -186,29 +161,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QPushButton" name="btn_reset">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="autoFillBackground">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Reset setttings to factory defaults</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0" colspan="3">
        <widget class="QCheckBox" name="opt_debug">
         <property name="minimumSize">
          <size>
@@ -236,6 +189,60 @@
         </property>
         <property name="tristate">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="btn_clear_cache">
+        <property name="text">
+         <string>Clear cache</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QLabel" name="lbl_version_saved_value">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="locale">
+         <locale language="English" country="UnitedStates"/>
+        </property>
+        <property name="text">
+         <string notr="true">X.X.X</string>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::NoTextInteraction</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="QPushButton" name="btn_reset">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Reset setttings to factory defaults</string>
         </property>
        </widget>
       </item>

--- a/gpf_isochrone_isodistance_itineraire/processing/get_capabities_parser.py
+++ b/gpf_isochrone_isodistance_itineraire/processing/get_capabities_parser.py
@@ -4,10 +4,12 @@ from typing import Any, Dict, List, Optional
 
 # PyQGIS
 from qgis.core import Qgis, QgsBlockingNetworkRequest, QgsRectangle
-from qgis.PyQt.QtCore import QUrl, QVariant
+from qgis.PyQt.QtCore import QByteArray, QUrl, QVariant
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
 from gpf_isochrone_isodistance_itineraire.constants import ISOCHRONE_OPERATION
+from gpf_isochrone_isodistance_itineraire.toolbelt.cache_manager import CacheManager
+from gpf_isochrone_isodistance_itineraire.toolbelt.file_stats import is_file_older_than
 from gpf_isochrone_isodistance_itineraire.toolbelt.log_handler import PlgLogger
 from gpf_isochrone_isodistance_itineraire.toolbelt.preferences import PlgOptionsManager
 
@@ -39,7 +41,7 @@ def get_available_operation(url_service: Optional[str] = None) -> List[str]:
     :return: list of available operations
     :rtype: List[str]
     """
-    data = download_getcapabilities(url_service)
+    data = getcapabilities_json(url_service)
     if data and "operations" in data:
         return [op["id"] for op in data["operations"]]
     return []
@@ -75,7 +77,7 @@ def get_available_resources(
     :return: list of available resources
     :rtype: List[str]
     """
-    data = download_getcapabilities(url_service)
+    data = getcapabilities_json(url_service)
     if data and "resources" in data:
         # If no operation filter return all resources
         if operation is None:
@@ -106,7 +108,7 @@ def get_resource_operation_parameters(
     :return: list of operation parameters
     :rtype: Optional[List[Any]]
     """
-    data = download_getcapabilities(url_service)
+    data = getcapabilities_json(url_service)
 
     if data and "resources" in data:
         # Parse resources to get available operation and check filter
@@ -337,6 +339,40 @@ def get_resource_cost_type(
         operation=ISOCHRONE_OPERATION,
         url_service=url_service,
     )
+
+
+def getcapabilities_json(url_service: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Returns getcapabilities json for an url.
+
+    First check if data is available in cache an not older than 24h
+    Otherwise a request is made to get value and save it in cache
+
+    :param url_service: url for service, defaults to None (plugin settings param is used)
+    :type url_service: Optional[str], optional
+    :return: json content for getcapabilities, None if error
+    :rtype: Optional[Dict[str, Any]]
+    """
+    # Check if cache available
+    cache_manager = CacheManager(".gpf_isochrone_isodistance", "cache")
+    getcap_cache_file = cache_manager.getcapabilities_cache_path(url_service)
+
+    # Check if file is available and not older than 24h
+    if is_file_older_than(
+        local_file_path=getcap_cache_file,
+        expiration_rotating_hours=24,
+    ):
+        result = download_getcapabilities(url_service=url_service, forceRefresh=True)
+        if result:
+            json_str = json.dumps(result)
+            cache_manager.save_cache_file_content(
+                getcap_cache_file, QByteArray(json_str.encode("utf-8"))
+            )
+    else:
+        # Load cache content
+        with open(getcap_cache_file, "r", encoding="utf-8") as f:
+            result = json.load(f)
+
+    return result
 
 
 def download_getcapabilities(

--- a/gpf_isochrone_isodistance_itineraire/processing/get_capabities_parser.py
+++ b/gpf_isochrone_isodistance_itineraire/processing/get_capabities_parser.py
@@ -353,7 +353,7 @@ def getcapabilities_json(url_service: Optional[str] = None) -> Optional[Dict[str
     :rtype: Optional[Dict[str, Any]]
     """
     # Check if cache available
-    cache_manager = CacheManager(".gpf_isochrone_isodistance", "cache")
+    cache_manager = CacheManager()
     getcap_cache_file = cache_manager.getcapabilities_cache_path(url_service)
 
     # Check if file is available and not older than 24h

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/application_folder.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/application_folder.py
@@ -34,7 +34,7 @@ def _posixify(in_name: str) -> str:
 
 @lru_cache
 def get_app_dir(
-    dir_name: str, roaming: bool = True, app_prefix: str = ".gpg_isochrone_isodistance"
+    dir_name: str, roaming: bool = True, app_prefix: str = ".geoplateforme/isoservices"
 ) -> Path:
     """Get application directory, typically cache or config folder.  The default
         behavior is to return whatever is most appropriate for the operating system.

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/application_folder.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/application_folder.py
@@ -1,0 +1,66 @@
+#! python3  # noqa: E265
+
+"""Find application folder.
+
+Inspired from Click: https://github.com/pallets/click/blob/14f735cf59618941cf2930e633eb77651b1dc7cb/src/click/utils.py#L449
+
+"""
+
+# ############################################################################
+# ########## Imports ###############
+# ##################################
+
+# standard library
+from functools import lru_cache
+from os import getenv
+from pathlib import Path
+
+# ############################################################################
+# ########## Functions #############
+# ##################################
+
+
+def _posixify(in_name: str) -> str:
+    """Make sure a string is POSIX friendly.
+
+    :param in_name: input string to posixify
+    :type name: str
+
+    :return: posixyfied string
+    :rtype: str
+    """
+    return "-".join(in_name.split()).lower()
+
+
+@lru_cache
+def get_app_dir(
+    dir_name: str, roaming: bool = True, app_prefix: str = ".gpg_isochrone_isodistance"
+) -> Path:
+    """Get application directory, typically cache or config folder.  The default
+        behavior is to return whatever is most appropriate for the operating system.
+
+    :param dir_name: the directory name. Could be cache of config for example.
+    :type dir_name: str
+    :param roaming: controls if the folder should be roaming or not on Windows. Has no
+        effect otherwise, defaults to True
+    :type roaming: bool, optional
+    :param app_prefix: application prefix, defaults to ".oslandia"
+    :type app_prefix: str, optional
+
+    :return: application folder path
+    :rtype: Path
+
+    :example:
+
+        .. code-block:: python
+
+            print(get_app_dir(dir_name="cache"))
+            # Mac OS X: ~/Library/Application Support/.oslandia/cache
+            # Unix: /home/<username>/.oslandia/cache
+            # Windows (roaming): C:\\Users\\<user>\\AppData\\Roaming\\.oslandia\\cache
+            print(get_app_dir(dir_name="cache", roaming=False))
+            # Windows (not roaming): C:\\Users\\<user>\\AppData\\Local\\.oslandia\\cache
+    """
+    key = "APPDATA" if roaming else "LOCALAPPDATA"
+    base_folder = Path(getenv(key, Path.home()))
+    return base_folder.joinpath(f"{app_prefix}/{_posixify(dir_name)}")

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/cache_manager.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/cache_manager.py
@@ -1,0 +1,154 @@
+# standard
+import shutil
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+# PyQGIS
+from qgis.core import Qgis
+from qgis.PyQt.QtCore import QByteArray, QCoreApplication, QFile, QIODevice
+
+# project
+import gpf_isochrone_isodistance_itineraire.toolbelt.log_handler as log_hdlr
+from gpf_isochrone_isodistance_itineraire.toolbelt.application_folder import get_app_dir
+
+
+class CacheManager:
+    """Class for local cache management."""
+
+    def __init__(self, app_prefix: str, dir_name: str):
+        """Init CacheManager class
+        For example on  linux with app_prefix = .qgis and dir_name = oslandia
+        cache_path = /home/toto/.qgis/plugin_oslandia/
+
+        :param app_prefix: Name of folder to prefix cache path
+        :type app_prefix: str
+        :param dir_name: Name of filder un prefix cache path
+        :type dir_name: str
+        """
+
+        self.cache_dir = get_app_dir(dir_name=dir_name, app_prefix=app_prefix)
+        self.log = log_hdlr.PlgLogger().log
+
+    def tr(self, message: str) -> str:
+        """Get the translation for a string using Qt translation API.
+
+        :param message: string to be translated.
+        :type message: str
+
+        :returns: Translated version of message.
+        :rtype: str
+        """
+        return QCoreApplication.translate(self.__class__.__name__, message)
+
+    @property
+    def get_cache_path(self) -> Path:
+        """Return cache path
+
+        :return: Cache path
+        :rtype: Path
+        """
+        return self.cache_dir
+
+    @staticmethod
+    def url_to_dirname(url: str) -> str:
+        parsed = urlparse(url)
+        # Get base url
+        netloc = parsed.netloc
+        # Replace / by _
+        path = parsed.path.strip("/").replace("/", "_")
+        return f"{netloc}_{path}" if path else netloc
+
+    def getcapabilities_cache_path(self, url_service: str) -> Path:
+        """Return cache path for a project upload
+
+        :param project_id: project id
+        :type project_id: str
+        :param upload_secret_and_name: "/uploads/{upload_secret}/{filename}" string
+        :type upload_secret_and_name: str
+        :return: upload cache path
+        :rtype: Path
+        """
+        dir_name = self.url_to_dirname(url_service)
+        return self.cache_dir / "getcapabilities" / dir_name
+
+    def load_cache_file_content(self, cache_file: Path) -> Optional[QByteArray]:
+        """Load cache file content if available
+
+        :param cache_file: cache file path
+        :type cache_file: Path
+        :return: file content if available and can be opened, None otherwise
+        :rtype: Optional[QByteArray]
+        """
+        # Load cache file if it exists
+        if cache_file.exists():
+            file = QFile(str(cache_file))
+            if file.open(QIODevice.OpenModeFlag.ReadOnly):
+                bytea = QByteArray(file.readAll())
+                file.close()
+                return bytea
+            else:
+                file.close()
+                err_msg = self.tr("Can't open cache file: {}".format(cache_file))
+                self.log(
+                    message=err_msg, log_level=Qgis.MessageLevel.Critical, push=True
+                )
+        return None
+
+    def save_cache_file_content(self, cache_file: Path, content: QByteArray) -> None:
+        """Save cache file content
+
+        :param cache_file: cache file path
+        :type cache_file: Path
+        :param content: cache content
+        :type content: QByteArray
+        """
+        # Save to cache
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        file = QFile(str(cache_file))
+        if file.open(QIODevice.OpenModeFlag.WriteOnly):
+            file.write(content)
+            file.close()
+        else:
+            err_msg = self.tr("Can't open cache file for write: {}".format(cache_file))
+            self.log(message=err_msg, log_level=Qgis.MessageLevel.Critical, push=True)
+
+    def ensure_cache_dir_exists(self) -> bool:
+        """Check if cache_dir exists
+
+        :return: True the cache dir already exists, otherwise false.
+        :rtype: bool
+        """
+        if not self.cache_dir.exists():
+            self.log(
+                message=f"The cache folder {self.cache_dir} doesn't exist.",
+                log_level=Qgis.MessageLevel.Info,
+            )
+            return False
+        else:
+            self.log(
+                message=f"Cache dir {self.cache_dir} already exists.",
+                log_level=Qgis.MessageLevel.Info,
+            )
+            return True
+
+    def create_cache_dir(self) -> None:
+        """Create cache_dir"""
+        if not self.ensure_cache_dir_exists():
+            self.cache_dir.mkdir(parents=True)
+            self.log(
+                message=f"Cache dir {self.cache_dir} has been created.",
+                log_level=Qgis.MessageLevel.NoLevel,
+            )
+
+    def clear_cache(self) -> None:
+        """Delete the cache_dir project"""
+        if self.ensure_cache_dir_exists():
+            shutil.rmtree(self.cache_dir)
+            self.log(
+                message=self.tr(
+                    "Cache dir {} has been removed.".format(self.cache_dir)
+                ),
+                log_level=Qgis.MessageLevel.Info,
+                push=True,
+            )

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/cache_manager.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/cache_manager.py
@@ -16,7 +16,9 @@ from gpf_isochrone_isodistance_itineraire.toolbelt.application_folder import get
 class CacheManager:
     """Class for local cache management."""
 
-    def __init__(self, app_prefix: str, dir_name: str):
+    def __init__(
+        self, app_prefix: str = ".geoplateforme/isoservices", dir_name: str = "cache"
+    ):
         """Init CacheManager class
         For example on  linux with app_prefix = .qgis and dir_name = oslandia
         cache_path = /home/toto/.qgis/plugin_oslandia/

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/file_stats.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/file_stats.py
@@ -1,0 +1,115 @@
+#! python3  # noqa: E265
+
+"""Check file statistcs."""
+
+# ############################################################################
+# ########## IMPORTS #############
+# ################################
+
+# standard library
+import logging
+from datetime import datetime, timedelta
+from functools import lru_cache
+from math import floor
+from math import log as math_log
+from pathlib import Path
+from sys import platform as opersys
+from typing import Literal
+
+# ############################################################################
+# ########## GLOBALS #############
+# ################################
+
+# logs
+logger = logging.getLogger(__name__)
+
+# ############################################################################
+# ########## FUNCTIONS ###########
+# ################################
+
+
+@lru_cache
+def convert_octets(octets: int) -> str:
+    """Convert a mount of octets in readable size.
+
+    Args:
+        octets: mount of octets to convert
+
+    Returns:
+        size in a human readable format: ko, Mo, etc.
+
+    Example:
+
+    .. code-block:: python
+
+        >>> convert_octets(1024)
+        1 ko
+        >>> from pathlib import Path
+        >>> convert_octets(Path(my_file.txt).stat().st_size)
+    """
+    # check zero
+    if octets == 0:
+        return "0 octet"
+
+    # conversion
+    size_name = ("octets", "Ko", "Mo", "Go", "To", "Po")
+    i = int(floor(math_log(octets, 1024)))
+    p = pow(1024, i)
+    s = round(octets / p, 2)
+
+    return f"{s} {size_name[i]}"
+
+
+def is_file_older_than(
+    local_file_path: Path,
+    expiration_rotating_hours: int = 24,
+    dt_reference_mode: Literal["auto", "creation", "modification"] = "auto",
+) -> bool:
+    """Check if the creation/modification date of the specified file is older than the \
+        mount of hours.
+
+    Args:
+        local_file_path (Path): local path to the file
+        expiration_rotating_hours (int, optional): number in hours to consider the \
+            local file outdated. Defaults to 24.
+        dt_reference_mode (Literal['auto', 'creation', 'modification'], optional):
+            reference date type: auto to handle differences between operating systems,
+            creation for creation date, modification for last modification date.
+            Defaults to "auto".
+
+    Returns:
+        bool: True if the creation/modification date of the file is older than the \
+            specified number of hours.
+    """
+    if not local_file_path.is_file() and not local_file_path.exists():
+        logger.debug(f"{local_file_path} does not exist.")
+        return True
+
+    # modification date varies depending on operating system: on some systems (like
+    # Unix) creation date is the time of the last metadata change, and, on others
+    # (like Windows), is the creation time for path.
+    if dt_reference_mode == "auto" and opersys == "win32":
+        dt_reference_mode = "modification"
+    else:
+        dt_reference_mode = "creation"
+
+    # get file reference datetime - modification or creation
+    if dt_reference_mode == "modification":
+        f_ref_dt = datetime.fromtimestamp(local_file_path.stat().st_mtime)
+        dt_type = "modified"
+    else:
+        f_ref_dt = datetime.fromtimestamp(local_file_path.stat().st_ctime)
+        dt_type = "created"
+
+    if (datetime.now() - f_ref_dt) < timedelta(hours=expiration_rotating_hours):
+        logger.debug(
+            f"{local_file_path} has been {dt_type} less than "
+            f"{expiration_rotating_hours} hours ago."
+        )
+        return False
+    else:
+        logger.debug(
+            f"{local_file_path} has been {dt_type} more than "
+            f"{expiration_rotating_hours} hours ago."
+        )
+        return True

--- a/tests/qgis/test_get_capabilities_parser.py
+++ b/tests/qgis/test_get_capabilities_parser.py
@@ -60,7 +60,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         }
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_isochrone_available_for_service(self, mock_download):
         """Test isochrone service available in operations
@@ -72,7 +72,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertTrue(getcap.isochrone_available_for_service())
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_isochrone_not_available_for_service(self, mock_download):
         """Test when service is not available
@@ -85,7 +85,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertFalse(getcap.isochrone_available_for_service())
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_available_operation(self, mock_download: MagicMock):
         """Check read of available operation
@@ -99,7 +99,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIn("route", operations)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_isochrone_available_for_resource(self, mock_download: MagicMock):
         """Check of isochrone operation for a resource
@@ -113,7 +113,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         )
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_isochrone_not_available_for_resource(self, mock_download: MagicMock):
         """Check of isochrone operation for a resource
@@ -125,7 +125,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertFalse(getcap.isochrone_available_for_resource(self.ROUTE_RESOURCE))
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_isochrone_for_invalid_resource(self, mock_download: MagicMock):
         """Check of isochrone operation for a invalid resource
@@ -137,7 +137,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertFalse(getcap.isochrone_available_for_resource("unavailable"))
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_available_resources(self, mock_download: MagicMock):
         """Get list of available resources for an operation
@@ -155,7 +155,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIn(self.ROUTE_RESOURCE, resources)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_operation_parameters(self, mock_download: MagicMock):
         """Get list of available parameter for a resource operation
@@ -175,7 +175,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIsNone(params)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_operation_parameters_values(self, mock_download: MagicMock):
         """Get list of available parameter values for a resource operation
@@ -206,7 +206,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertEqual(len(params), 0)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_profiles(self, mock_download: MagicMock):
         """Get list of available profile for a resource operation
@@ -219,7 +219,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIn("bike", profiles)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_crs(self, mock_download: MagicMock):
         """Get list of available crs for a resource operation
@@ -232,7 +232,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIn("EPSG:4326", crs)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_default_crs(self, mock_download: MagicMock):
         """Get default crs for a resource operation
@@ -247,7 +247,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertEqual(default_crs, "EPSG:4326")
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_direction(self, mock_download: MagicMock):
         """Get direction for a resource operation
@@ -260,7 +260,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIn("forward", directions)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_cost_type(self, mock_download: MagicMock):
         """Get cost type for a resource operation
@@ -273,7 +273,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIn("time", cost_types)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_param_bbox(self, mock_download: MagicMock):
         """Get bbox for a resource operation
@@ -296,7 +296,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIsNone(bbox)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_available_operation_with_empty_data(self, mock_download: MagicMock):
         """Check empty operation return for empty getcap
@@ -309,7 +309,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertEqual(operations, [])
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_available_resources_with_missing_operations(
         self, mock_download: MagicMock
@@ -326,7 +326,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertEqual(resources, [])
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_operation_parameters_invalid_resource(
         self, mock_download: MagicMock
@@ -343,7 +343,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIsNone(params)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_operation_parameters_invalid_operation(
         self, mock_download: MagicMock
@@ -360,7 +360,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIsNone(params)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_param_bbox_missing_bbox(self, mock_download: MagicMock):
         """Check None return for missing bbox
@@ -383,7 +383,7 @@ class TestGetCapabilitiesParser(unittest.TestCase):
         self.assertIsNone(bbox)
 
     @patch(
-        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.download_getcapabilities"
+        "gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser.getcapabilities_json"
     )
     def test_get_resource_profiles_with_invalid_data(self, mock_download: MagicMock):
         """Check empty profiles return if no data available


### PR DESCRIPTION
- ajout classe pour gestion du cache : `CacheManager`
- ajout outil pour vérification sur fichier : `gpf_isochrone_isodistance_itineraire/toolbelt/file_stats.py`
- sauvegarde du résultat du getcapabilities pour un service dans le cache local pour éviter des requetes multiple
- une nouvelle requête est effectuée si le cache a plus d'une journée