### PR TITLE
feat(isoservice): add widget to use isoservice

### DIFF
--- a/gpf_isochrone_isodistance_itineraire/gui/wdg_iso_service.py
+++ b/gpf_isochrone_isodistance_itineraire/gui/wdg_iso_service.py
@@ -1,0 +1,163 @@
+"""Widget to launch iso service processing"""
+
+# standard
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# PyQGIS
+from qgis.core import (
+    QgsApplication,
+    QgsFeature,
+    QgsFields,
+    QgsGeometry,
+    QgsProcessingContext,
+    QgsProject,
+    QgsVectorLayer,
+)
+from qgis.PyQt import uic
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QWidget
+
+# project
+from gpf_isochrone_isodistance_itineraire.constants import ISOCHRONE_OPERATION
+from gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser import (
+    get_available_resources,
+    get_resource_direction,
+    get_resource_profiles,
+)
+from gpf_isochrone_isodistance_itineraire.processing.gpf_iso_service import (
+    GpfIsoServiceProcessing,
+)
+
+
+class IsoServiceWidget(QWidget):
+    """QWidget to launch iso service processing
+
+    :param parent: dialog parent, defaults to None
+    :type parent: Optional[QWidget], optional
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        ui_path = Path(__file__).resolve(True).parent / "wdg_iso_service.ui"
+        uic.loadUi(ui_path, self)
+
+        # Get list of available resource from getcap
+        available_resource = get_available_resources(operation=ISOCHRONE_OPERATION)
+        self.cbx_resource.clear()
+        self.cbx_resource.addItems(available_resource)
+
+        self.cbx_resource.currentIndexChanged.connect(self._resource_changed)
+        self._resource_changed()
+
+        self.btn_run.setIcon(QIcon(":images/themes/default/mActionStart.svg"))
+        self.btn_run.clicked.connect(self._run_processing)
+        self.rbtn_isochrone.clicked.connect(self._service_changed)
+        self.rbtn_isodistance.clicked.connect(self._service_changed)
+        self._service_changed()
+
+        self.memory_layer = None
+
+    def _service_changed(self) -> None:
+        """Update labels and maximum value for max cost depending on service used"""
+        if self.rbtn_isochrone.isChecked():
+            label_str = self.tr("Durée maximale")
+            suffix_str = self.tr(" s")
+            max_value = 100000.0
+        else:
+            label_str = self.tr("Distance maximale")
+            suffix_str = self.tr(" km")
+            max_value = 500.0
+        self.lbl_max_cost.setText(label_str)
+        self.spb_max_cost.setSuffix(suffix_str)
+        self.spb_max_cost.setMaximum(max_value)
+
+    def _get_isoservice_processing(self) -> str:
+        """Return processing name for selected isoservice
+
+        :return: processing name
+        :rtype: str
+        """
+        if self.rbtn_isochrone.isChecked():
+            return "gpf_isochrone_isodistance_itineraire:isochrone_processing"
+        return "gpf_isochrone_isodistance_itineraire:isodistance_processing"
+
+    def _run_processing(self) -> None:
+        """Run processing for selected point and algorithm parameters"""
+
+        # Create a temporary memory layer with selected point
+        # Must be stored in class to be able to use it in a QgsTask
+        self.memory_layer = self._create_input_layer()
+
+        # Get algorithm
+        algo_str = self._get_isoservice_processing()
+        alg = QgsApplication.processingRegistry().algorithmById(algo_str)
+
+        # Define parameters
+        params = {
+            "INPUT": self.memory_layer,
+            GpfIsoServiceProcessing.ID_RESOURCE: self.cbx_resource.currentText(),
+            GpfIsoServiceProcessing.PROFILE: self.cbx_profil.currentText(),
+            GpfIsoServiceProcessing.DIRECTION: self.cbx_direction.currentText(),
+            GpfIsoServiceProcessing.MAX_COST: self.spb_max_cost.value(),
+            GpfIsoServiceProcessing.ADDITIONAL_URL_PARAM: self.txt_additionnal_request.toPlainText(),
+            "OUTPUT": "TEMPORARY_OUTPUT",
+        }
+
+        # Run algorithm
+        self.txt_processing_run.run_alg(alg, params, self._isoservice_computed)
+
+    def _isoservice_computed(
+        self, context: QgsProcessingContext, successful: bool, results: Dict[str, Any]
+    ) -> None:
+        """Load result after algorithm run
+
+        :param context: processing context (used to get created layer)
+        :type context: QgsProcessingContext
+        :param successful: True if algorithm was succesful, False otherwise
+        :type successful: bool
+        :param results: algorithm result dict
+        :type results: Dict[str, Any]
+        """
+        if successful:
+            output_id = results["OUTPUT"]
+            if isolayer := context.getMapLayer(output_id):
+                QgsProject.instance().addMapLayer(isolayer)
+
+    def _create_input_layer(self) -> QgsVectorLayer:
+        """Create an input layer from selected point
+
+        :return: input layer for algorithm
+        :rtype: QgsVectorLayer
+        """
+        layer = QgsVectorLayer(
+            f"Point?crs={self.wdg_point_selection.get_crs().authid()}",
+            "Point sélectionné",
+            "memory",
+        )
+
+        feature = QgsFeature(QgsFields())
+        feature.setGeometry(
+            QgsGeometry.fromPointXY(self.wdg_point_selection.get_displayed_point())
+        )
+
+        layer.dataProvider().addFeatures([feature])
+
+        return layer
+
+    def _resource_changed(self) -> None:
+        """Update available profil and direction for selected resource"""
+        resource = self.cbx_resource.currentText()
+
+        # Update profiles
+        profiles = get_resource_profiles(
+            id_resource=resource, operation=ISOCHRONE_OPERATION
+        )
+        self.cbx_profil.clear()
+        self.cbx_profil.addItems(profiles)
+
+        # Update directions
+        directions = get_resource_direction(id_resource=resource)
+
+        self.cbx_direction.clear()
+        self.cbx_direction.addItems(directions)

--- a/gpf_isochrone_isodistance_itineraire/gui/wdg_iso_service.ui
+++ b/gpf_isochrone_isodistance_itineraire/gui/wdg_iso_service.ui
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>620</width>
+    <height>421</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <item row="12" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="3">
+    <widget class="QToolButton" name="btn_run">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QRadioButton" name="rbtn_isodistance">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Isodistance</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbtn_isochrone">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Isochrone</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="9" column="0" colspan="3">
+    <widget class="PointSelectionWidget" name="wdg_point_selection" native="true"/>
+   </item>
+   <item row="7" column="0" colspan="4">
+    <layout class="QGridLayout" name="gridLayout_3">
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="cbx_profil"/>
+     </item>
+     <item row="0" column="1" colspan="3">
+      <widget class="QComboBox" name="cbx_resource"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="lbl_resource">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Ressource</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLabel" name="lbl_direction">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Direction</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QComboBox" name="cbx_direction"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lbl_profil">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Profil</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="lbl_max_cost">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Distance maximale</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1" colspan="3">
+      <widget class="QDoubleSpinBox" name="spb_max_cost">
+       <property name="suffix">
+        <string> km</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="0" colspan="4">
+    <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+     <property name="title">
+      <string>Paramètres avancés</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lbl_additionnal_request">
+        <property name="text">
+         <string>Paramètres additionnels pour la requête</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QTextEdit" name="txt_additionnal_request"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="4">
+    <widget class="ProcessingRunTextEdit" name="txt_processing_run"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PointSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>gpf_isochrone_isodistance_itineraire.toolbelt.wdg_point_selection</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ProcessingRunTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header>gpf_isochrone_isodistance_itineraire.toolbelt.txt_processing_run</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/gpf_isochrone_isodistance_itineraire/processing/get_capabities_parser.py
+++ b/gpf_isochrone_isodistance_itineraire/processing/get_capabities_parser.py
@@ -352,6 +352,10 @@ def getcapabilities_json(url_service: Optional[str] = None) -> Optional[Dict[str
     :return: json content for getcapabilities, None if error
     :rtype: Optional[Dict[str, Any]]
     """
+    if not url_service:
+        plg_settings = PlgOptionsManager().get_plg_settings()
+        url_service = plg_settings.url_service
+
     # Check if cache available
     cache_manager = CacheManager()
     getcap_cache_file = cache_manager.getcapabilities_cache_path(url_service)

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/processing_feedback.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/processing_feedback.py
@@ -1,0 +1,113 @@
+import sys
+from typing import Optional
+
+from qgis.core import QgsProcessingFeedback
+from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot
+from qgis.PyQt.QtGui import QColor
+from qgis.PyQt.QtWidgets import QTextEdit
+
+
+class QTextEditProcessingFeedBack(QgsProcessingFeedback):
+    insert_text_color = pyqtSignal(str, QColor)
+
+    def __init__(self, text_edit: QTextEdit):
+        """QgsProcessingFeedback to display feedback in a QTextEdit
+
+        :param text_edit: text edit to display feedback
+        :type text_edit: QTextEdit
+        """
+        super().__init__()
+        self._text_edit = text_edit
+
+        # Define font depending on platform
+        if sys.platform.startswith("win"):
+            self._text_edit.setFontFamily("Courier New")
+        else:
+            self._text_edit.setFontFamily("monospace")
+
+        self._text_edit.setReadOnly(True)
+        self._text_edit.setUndoRedoEnabled(False)
+
+        self.insert_text_color.connect(self._change_color_and_insert_text)
+
+    def setProgressText(self, text: Optional[str]):
+        """Sets a progress report text string. This can be used in conjunction with setProgress() to provide detailed progress reports, such as “Transformed 4 of 5 layers”.
+
+        :param text: progress text
+        :type text: Optional[str]
+        """
+        super().setProgressText(text)
+        self.pushInfo(text)
+
+    def pushWarning(self, warning: Optional[str]):
+        """Pushes a warning informational message from the algorithm. This should only be used sparsely as to maintain the importance of visual queues associated to this type of message.
+
+        :param warning: warning text
+        :type warning: Optional[str]
+        """
+        super().pushWarning(warning)
+        self.insert_text_color.emit(warning, QColor("orange"))
+
+    def pushInfo(self, info: Optional[str]):
+        """Pushes a general informational message from the algorithm. This can be used to report feedback which is neither a status report or an error, such as “Found 47 matching features”.
+
+        :param info: info text
+        :type info: Optional[str]
+        """
+        super().pushInfo(info)
+        self.insert_text_color.emit(info, QColor("black"))
+
+    def pushCommandInfo(self, info: str):
+        """Pushes an informational message containing a command from the algorithm. This is usually used to report commands which are executed in an external application or as subprocesses.
+
+        :param info: info text
+        :type info: Optional[str]
+        """
+        super().pushCommandInfo(info)
+        self.pushInfo(info)
+
+    def pushDebugInfo(self, info: Optional[str]):
+        """Pushes an informational message containing debugging helpers from the algorithm.
+
+        :param info: info text
+        :type info: Optional[str]
+        """
+        super().pushDebugInfo(info)
+        self.pushInfo(info)
+
+    def pushConsoleInfo(self, info: Optional[str]):
+        """Pushes a console feedback message from the algorithm. This is used to report the output from executing an external command or subprocess.
+
+        :param info: info text
+        :type info: Optional[str]
+        """
+        super().pushConsoleInfo(info)
+        self.pushInfo(info)
+
+    def reportError(self, error: Optional[str], fatalError=False):
+        """Reports that the algorithm encountered an error while executing.
+
+           If fatalError is True then the error prevented the algorithm from executing.
+
+        :param error: error text
+        :type error: Optional[str]
+        :param fatalError: fatal error bool, defaults to False
+        :type fatalError: bool, optional
+        """
+        super().reportError(error, fatalError)
+        self.insert_text_color.emit(error, QColor("red"))
+
+    @pyqtSlot(str, QColor)
+    def _change_color_and_insert_text(self, text: Optional[str], color: QColor):
+        """Change current text edit color and insert text
+
+        :param text: text to insert
+        :type text: Optional[str]
+        :param color: color
+        :type color: QColor
+        """
+        if text:
+            self._text_edit.setTextColor(color)
+            self._text_edit.append(text)
+            sb = self._text_edit.verticalScrollBar()
+            sb.setValue(sb.maximum())

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/txt_processing_run.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/txt_processing_run.py
@@ -1,0 +1,76 @@
+# standard
+from functools import partial
+from typing import Any, Callable, Dict, Optional
+
+# pyQGIS
+from qgis.core import (
+    QgsApplication,
+    QgsProcessingAlgorithm,
+    QgsProcessingAlgRunnerTask,
+    QgsProcessingContext,
+    QgsProcessingFeedback,
+    QgsTask,
+)
+from qgis.PyQt.QtWidgets import QMessageBox, QTextEdit, QWidget
+
+# project
+from gpf_isochrone_isodistance_itineraire.toolbelt.processing_feedback import (
+    QTextEditProcessingFeedBack,
+)
+
+
+class ProcessingRunTextEdit(QTextEdit):
+    def __init__(self, parent: Optional[QWidget] = None):
+        """Text edit to run QgsProcessingAlgorithm and display feedback
+
+        :param parent: widget parent, defaults to None
+        :type parent: Optional[QWidget], optional
+        """
+        super().__init__(parent)
+        self.task: Optional[QgsTask] = None
+        self._feedback: Optional[QgsProcessingFeedback] = None
+        self.context: Optional[QgsProcessingContext] = None
+        self.setReadOnly(True)
+        self.setUndoRedoEnabled(False)
+
+    def run_alg(
+        self,
+        alg: QgsProcessingAlgorithm,
+        params: Dict[str, Any],
+        executed_callback: Optional[Callable],
+        *args,
+    ):
+        """Run algorithm and display feedback in text edit.
+
+        If executed_callback is defined it must have arguments for context and task return
+
+        Example:
+            def _isoservice_computed(self, context : QgsProcessingContext, successful :bool, results : Dict[str,Any]) -> None:
+
+        :param alg: algorithm to run
+        :type alg: QgsProcessingAlgorithm
+        :param params: algorithm parameters
+        :type params: Dict[str,Any]
+        :param executed_callback: callback to call after execution
+        :type executed_callback: Callable
+        """
+
+        self.context = QgsProcessingContext()
+        res, error = alg.checkParameterValues(params, self.context)
+        if res:
+            self.clear()
+            self._feedback = QTextEditProcessingFeedBack(self)
+            self._task = QgsProcessingAlgRunnerTask(
+                alg, params, self.context, self._feedback
+            )
+            if executed_callback:
+                self._task.executed.connect(
+                    partial(executed_callback, self.context, *args)
+                )
+            QgsApplication.taskManager().addTask(self._task)
+        else:
+            QMessageBox.critical(
+                self,
+                self.tr("Can't run {0}".format(alg.name())),
+                self.tr("Invalid parameters : {0}.".format(error)),
+            )

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/wdg_point_selection.py
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/wdg_point_selection.py
@@ -1,0 +1,218 @@
+"""Widget to select point on canvas for a specified CRS"""
+
+# standard
+from pathlib import Path
+from typing import Optional, Union
+
+# PyQGIS
+from qgis.core import (
+    Qgis,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsPointXY,
+    QgsRectangle,
+)
+from qgis.gui import QgsMapToolEmitPoint, QgsProjectionSelectionDialog, QgsVertexMarker
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QColor, QIcon
+from qgis.PyQt.QtWidgets import QWidget
+from qgis.utils import iface
+
+
+class PointSelectionWidget(QWidget):
+    """Widget to select point on canvas for a specified CRS
+
+    :param parent: dialog parent, defaults to None
+    :type parent: Optional[QWidget], optional
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        ui_path = Path(__file__).resolve(True).parent / "wdg_point_selection.ui"
+        uic.loadUi(ui_path, self)
+
+        # Add marker for selected point
+        self.marker = QgsVertexMarker(iface.mapCanvas())
+        self.marker.setColor(QColor("red"))
+        self.marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
+        self.marker.setIconSize(12)
+        self.marker.setPenWidth(3)
+
+        # Not visible until maptool is activated
+        self.marker.setVisible(False)
+
+        # Connect to value changes for marker coordinate update
+        self.spb_x.valueChanged.connect(self._update_marker_position)
+        self.spb_y.valueChanged.connect(self._update_marker_position)
+
+        # By default use current mapCanvas destination Crs
+        self._current_crs = iface.mapCanvas().mapSettings().destinationCrs()
+        self.set_crs(self._current_crs)
+
+        # Create maptool for position selection
+        self._previous_map_tool = None
+        self._map_tool = QgsMapToolEmitPoint(iface.mapCanvas())
+        self._map_tool.canvasClicked.connect(self._point_selected)
+
+        self.btn_select_point.setIcon(
+            QIcon(":images/themes/default/cursors/mCapturePoint.svg")
+        )
+        self.btn_select_point.clicked.connect(self._selection_clicked)
+
+        self.btn_projection.setIcon(
+            QIcon(":images/themes/default/propertyicons/CRS.svg")
+        )
+        self.btn_projection.clicked.connect(self._select_crs)
+
+    def get_displayed_point(self) -> QgsPointXY:
+        """Return displayed point
+
+        :return: displayed point
+        :rtype: QgsPointXY
+        """
+        return QgsPointXY(self.spb_x.value(), self.spb_y.value())
+
+    def set_display_point(self, point: QgsPointXY) -> None:
+        """Define display point and update marker
+
+        :param point: point to display
+        :type point: QgsPointXY
+        """
+
+        self.spb_x.valueChanged.disconnect(self._update_marker_position)
+        self.spb_y.valueChanged.disconnect(self._update_marker_position)
+
+        self.spb_x.setValue(point.x())
+        self.spb_y.setValue(point.y())
+
+        self.spb_x.valueChanged.connect(self._update_marker_position)
+        self.spb_y.valueChanged.connect(self._update_marker_position)
+
+        self._update_marker_position()
+
+    def _update_marker_position(self) -> None:
+        """Update marker with new point values"""
+        point = self.get_displayed_point()
+        new_point = self._transform(
+            point, self._current_crs, iface.mapCanvas().mapSettings().destinationCrs()
+        )
+        self.marker.setCenter(new_point)
+
+    def get_crs(self) -> QgsCoordinateReferenceSystem:
+        """Get crs
+
+        :return: crs used
+        :rtype: QgsCoordinateReferenceSystem
+        """
+        return self._current_crs
+
+    def set_crs(self, crs: QgsCoordinateReferenceSystem) -> None:
+        """Define crs used, current displayed point is transformed
+
+        :param crs: new crs
+        :type crs: QgsCoordinateReferenceSystem
+        """
+        # Update point with new crs
+        new_point = self._transform(self.get_displayed_point(), self._current_crs, crs)
+
+        # Update spinbox min/max value
+        self._update_spinbox_for_crs(crs)
+
+        # Store used crs, need to be done before point display for marker coordinate transform
+        self._current_crs = crs
+
+        # Display projected point
+        self.set_display_point(new_point)
+
+    def _select_crs(self):
+        """Select new crs"""
+        selector = QgsProjectionSelectionDialog(iface.mainWindow())
+        selector.setCrs(self._current_crs)
+        if selector.exec():
+            self.set_crs(selector.crs())
+
+    def _update_spinbox_for_crs(self, crs: QgsCoordinateReferenceSystem) -> None:
+        """Update X,Y spinbox with crs bounds
+
+        :param crs: crs
+        :type crs: QgsCoordinateReferenceSystem
+        """
+        bounds = crs.bounds()
+
+        # CRS bounds are always defined in EPSG:4362, convert for X,Y min and max value
+        bounds = self._transform(
+            crs.bounds(), QgsCoordinateReferenceSystem("EPSG:4326"), crs
+        )
+
+        self.spb_x.setMinimum(bounds.xMinimum())
+        self.spb_x.setMaximum(bounds.xMaximum())
+        self.spb_y.setMinimum(bounds.yMinimum())
+        self.spb_y.setMaximum(bounds.yMaximum())
+
+        if crs.mapUnits() == Qgis.DistanceUnit.Degrees:
+            decimal = 5
+            step = 0.1
+        else:
+            decimal = 3
+            step = 10
+
+        self.spb_x.setDecimals(decimal)
+        self.spb_x.setSingleStep(step)
+        self.spb_y.setDecimals(decimal)
+        self.spb_y.setSingleStep(step)
+
+    def _selection_clicked(self) -> None:
+        """Update maptool used and display marker if activated"""
+        if self.btn_select_point.isChecked():
+            # Keep previous map tool to be able to restore it
+            self._previous_map_tool = iface.mapCanvas().mapTool()
+
+            iface.mapCanvas().setMapTool(self._map_tool)
+            self._map_tool.activate()
+
+            self.marker.setVisible(True)
+            self._update_marker_position()
+        else:
+            self._map_tool.deactivate()
+
+            self.marker.setVisible(False)
+            # Restore previous map tool if available
+            if self._previous_map_tool:
+                iface.mapCanvas().setMapTool(self._previous_map_tool)
+
+    def _point_selected(self, point: QgsPointXY, button: Qt.MouseButton) -> None:
+        """Update displayed point after selection
+
+        :param point: selected point
+        :type point: QgsPointXY
+        :param button: button used for selection (unused)
+        :type button: Qt.MouseButton
+        """
+        # Update point with wanted crs
+        new_point = self._transform(
+            point, iface.mapCanvas().mapSettings().destinationCrs(), self._current_crs
+        )
+        self.set_display_point(new_point)
+
+    @staticmethod
+    def _transform(
+        geom: Union[QgsPointXY, QgsRectangle],
+        src: QgsCoordinateReferenceSystem,
+        dest: QgsCoordinateReferenceSystem,
+    ) -> Union[QgsPointXY, QgsRectangle]:
+        """Transform geometry from a source CRS to a destination CRS
+
+        :param geom: input geom
+        :type geom: Union[QgsPointXY, QgsRectangle]
+        :param src: source crs
+        :type src: QgsCoordinateReferenceSystem
+        :param dest: destination crs
+        :type dest: QgsCoordinateReferenceSystem
+        :return: transformed geometry
+        :rtype: Union[QgsPointXY, QgsRectangle]
+        """
+        transform = QgsCoordinateTransform()
+        transform.setSourceCrs(src)
+        transform.setDestinationCrs(dest)
+        return transform.transform(geom)

--- a/gpf_isochrone_isodistance_itineraire/toolbelt/wdg_point_selection.ui
+++ b/gpf_isochrone_isodistance_itineraire/toolbelt/wdg_point_selection.ui
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PointSelectionWidget</class>
+ <widget class="QWidget" name="PointSelectionWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>426</width>
+    <height>26</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="1">
+    <widget class="QLabel" name="lbl_x">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>X</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QDoubleSpinBox" name="spb_x">
+     <property name="minimum">
+      <double>-10000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>10000000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QDoubleSpinBox" name="spb_y">
+     <property name="minimum">
+      <double>-100000000000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100000000000000000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="5">
+    <widget class="QToolButton" name="btn_select_point">
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="lbl_y">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Y</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QToolButton" name="btn_projection">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
- ajout d'un widget pour sélection d'un point sur la carte pour un CRS choisi : `PointSelectionWidget`:
    -  utilisation de `QgsMapToolEmitPoint` pour récupération de la position sur la carte
    - affichage de la position avec un `QgsVertexMarker`
    - transformation de la position pour le CRS souhaité
    - déplacement du marqueur lors de la modification des X/Y
    - limitation valeur X/Y selon bounds du CRS
- ajout d'un widget pour lancement et affichage des logs d'un processing `ProcessingRunTextEdit`
    - utilisation d'un feedback custom pour affichage des logs `QTextEditProcessingFeedBack`
    - lancement du processing avec un tache `QgsProcessingAlgRunnerTask`
    - retour d'execution du processing dans une callback
- ajout d'un widget pour définition des paramètres pour utilisation d'un isoservice (distance / durée)
    - choix du type de service
    - récupération des resources disponibles selon le getcap du service
    - récupération des profils et direction selon la resource sélectionnée
    - lancement du processing avec `ProcessingRunTextEdit`
    - ajout résultat dans le projet courant

Screencast:

[Screencast from 2025-04-25 11-21-17.webm](https://github.com/user-attachments/assets/9d41b5ad-ca92-4dd1-a0ad-275e2dcf8ac9)


🎫 JIRA :
- https://jira.worldline-solutions.com/browse/IGNGPF-4847
- https://jira.worldline-solutions.com/browse/IGNGPF-4844