### PR TITLE
fix(ci): fill missing qgis-plugin-ci settings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,8 @@ description-file = README.md
 
 [qgis-plugin-ci]
 plugin_path = gpf_isochrone_isodistance_itineraire
-project_slug = TO BE SET WITH THE GITLAB/GITHUB SLUGIFIED PROJECT NAME (IN PROJECT'S URL)
-
-github_organization_slug = TO BE SET WITH THE GITHUB USER/ORGANIZATION NAME
-
+project_slug = plugin-qgis-gpf-isochrone-isodistance-itineraire
+github_organization_slug = Geoplateforme
 
 # -- Code quality ------------------------------------
 


### PR DESCRIPTION
Devrait corriger https://github.com/Geoplateforme/plugin-qgis-gpf-isochrone-isodistance-itineraire/actions/runs/14727376131/job/41333253361