### PR TITLE
feat(gpf): add function create_gpf_plugins_actions to be called by geoplateforme plugin

### DIFF
--- a/gpf_isochrone_isodistance_itineraire/gui/wdg_iso_service.py
+++ b/gpf_isochrone_isodistance_itineraire/gui/wdg_iso_service.py
@@ -18,6 +18,8 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QWidget
 
+from gpf_isochrone_isodistance_itineraire.__about__ import DIR_PLUGIN_ROOT
+
 # project
 from gpf_isochrone_isodistance_itineraire.constants import ISOCHRONE_OPERATION
 from gpf_isochrone_isodistance_itineraire.processing.get_capabities_parser import (
@@ -41,6 +43,10 @@ class IsoServiceWidget(QWidget):
         super().__init__(parent)
         ui_path = Path(__file__).resolve(True).parent / "wdg_iso_service.ui"
         uic.loadUi(ui_path, self)
+
+        self.setWindowIcon(
+            QIcon(str(DIR_PLUGIN_ROOT / "resources/images/logo_isoservices.svg"))
+        )
 
         # Get list of available resource from getcap
         available_resource = get_available_resources(operation=ISOCHRONE_OPERATION)

--- a/gpf_isochrone_isodistance_itineraire/processing/utils.py
+++ b/gpf_isochrone_isodistance_itineraire/processing/utils.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+from qgis import processing
+from qgis.core import Qgis, QgsApplication
+from qgis.PyQt.QtCore import QObject
+from qgis.PyQt.QtWidgets import QAction
+
+from gpf_isochrone_isodistance_itineraire.toolbelt.log_handler import PlgLogger
+
+
+def create_processing_action(algorithm_id: str, parent: QObject) -> Optional[QAction]:
+    """Create action to display a processing dialog for an algorithm
+
+    :param algorithm_id: algorithm id
+    :type algorithm_id: str
+    :param parent: parent for QAction
+    :type parent: QObject
+    :return: QAction connected to processing dialog display, None if processing is not available.
+    :rtype: Optional[QAction]
+    """
+    registry = QgsApplication.processingRegistry()
+    alg = registry.algorithmById(algorithm_id)
+
+    if alg is None:
+        PlgLogger().log(
+            f"Algorithme '{algorithm_id}' non trouvé.",
+            log_level=Qgis.MessageLevel.Warning,
+        )
+        return None
+
+    action = QAction(alg.icon(), alg.displayName(), parent)
+    action.setToolTip(alg.shortHelpString())
+
+    action.triggered.connect(lambda: processing.execAlgorithmDialog(algorithm_id))
+
+    return action


### PR DESCRIPTION
Afin de pouvoir intégrer des actions du plugin isoservice / itinéraire dans le plugin géoplateforme, la fonction `create_gpf_plugins_actions` est implémentée dans le plugin.

Pour l'instant les actions suivantes sont ajoutées:

- affichage du widget de calcul d'isodistance / isochrone
- affichage des processings isodistance / isochrone

L'icone pour le widget de calcul d'isodistance / isochrone est aussi mise à jour.