### PR TITLE
fix(qt6): QMenu need a parent in Qt6 for correct use

### DIFF
--- a/gpf_isochrone_isodistance_itineraire/plugin_main.py
+++ b/gpf_isochrone_isodistance_itineraire/plugin_main.py
@@ -247,7 +247,7 @@ class GpfIsochroneIsodistanceItinerairePlugin:
             self.tr("Isoservices"),
             parent,
         )
-        iso_service_menu = QMenu()
+        iso_service_menu = QMenu(parent)
         if self.isoservice_widget_action:
             iso_service_menu.addAction(self.isoservice_widget_action)
 
@@ -288,7 +288,7 @@ class GpfIsochroneIsodistanceItinerairePlugin:
             self.tr("Itineraire"),
             parent,
         )
-        itinerary_menu = QMenu()
+        itinerary_menu = QMenu(parent)
         if self.itinerary_widget_action:
             itinerary_menu.addAction(self.itinerary_widget_action)
 


### PR DESCRIPTION
related https://github.com/Geoplateforme/plugin-qgis-geoplateforme/issues/276